### PR TITLE
Adding support for 1.12 org.craftbukkit

### DIFF
--- a/src/de/CodingAir/ClanSystem/Listeners/AllianceListener.java
+++ b/src/de/CodingAir/ClanSystem/Listeners/AllianceListener.java
@@ -27,19 +27,24 @@ public class AllianceListener implements Listener {
 				projectile = e.getDamager();
 				
 				try {
-					org.bukkit.craftbukkit.v1_11_R1.entity.CraftArrow arrow = (org.bukkit.craftbukkit.v1_11_R1.entity.CraftArrow) damager;
+					org.bukkit.craftbukkit.v1_12_R1.entity.CraftArrow arrow = (org.bukkit.craftbukkit.v1_12_R1.entity.CraftArrow) damager;
 					if(arrow.getShooter() instanceof Player) d = (Player) arrow.getShooter();
 				} catch(NoClassDefFoundError ex) {
 					try {
-						org.bukkit.craftbukkit.v1_10_R1.entity.CraftArrow arrow = (org.bukkit.craftbukkit.v1_10_R1.entity.CraftArrow) damager;
-						if(arrow.getShooter() instanceof Player) d = (Player) arrow.getShooter();
-					} catch(NoClassDefFoundError ex1) {
+						org.bukkit.craftbukkit.v1_11_R1.entity.CraftArrow arrow = (org.bukkit.craftbukkit.v1_11_R1.entity.CraftArrow) damager;
+						if (arrow.getShooter() instanceof Player) d = (Player) arrow.getShooter();
+					} catch (NoClassDefFoundError ex0) {
 						try {
-							org.bukkit.craftbukkit.v1_9_R1.entity.CraftArrow arrow = (org.bukkit.craftbukkit.v1_9_R1.entity.CraftArrow) damager;
-							if(arrow.getShooter() instanceof Player) d = (Player) arrow.getShooter();
-						} catch(NoClassDefFoundError ex2) {
-							org.bukkit.craftbukkit.v1_8_R3.entity.CraftArrow arrow = (org.bukkit.craftbukkit.v1_8_R3.entity.CraftArrow) damager;
-							if(arrow.getShooter() instanceof Player) d = (Player) arrow.getShooter();
+							org.bukkit.craftbukkit.v1_10_R1.entity.CraftArrow arrow = (org.bukkit.craftbukkit.v1_10_R1.entity.CraftArrow) damager;
+							if (arrow.getShooter() instanceof Player) d = (Player) arrow.getShooter();
+						} catch (NoClassDefFoundError ex1) {
+							try {
+								org.bukkit.craftbukkit.v1_9_R1.entity.CraftArrow arrow = (org.bukkit.craftbukkit.v1_9_R1.entity.CraftArrow) damager;
+								if (arrow.getShooter() instanceof Player) d = (Player) arrow.getShooter();
+							} catch (NoClassDefFoundError ex2) {
+								org.bukkit.craftbukkit.v1_8_R3.entity.CraftArrow arrow = (org.bukkit.craftbukkit.v1_8_R3.entity.CraftArrow) damager;
+								if (arrow.getShooter() instanceof Player) d = (Player) arrow.getShooter();
+							}
 						}
 					}
 				}


### PR DESCRIPTION
This PR adds 1.12 support for EntityDamageByEntityEvent by adding new try that checks if `org.bukkit.craftbukkit.v1_12_R1` is available.
Without it 1.12 server will return `NoClassDefFoundError` on arrow damage.